### PR TITLE
Fixes renderFlex overflow in todo_tile

### DIFF
--- a/lib/util/todo_tile.dart
+++ b/lib/util/todo_tile.dart
@@ -32,22 +32,18 @@ class ToDoTile extends StatelessWidget {
           ],
         ),
         child: Container(
-          padding: EdgeInsets.all(24),
-          decoration: BoxDecoration(
-            color: Colors.yellow,
-            borderRadius: BorderRadius.circular(12),
-          ),
-          child: Row(
-            children: [
-              // checkbox
-              Checkbox(
+            padding: EdgeInsets.all(24),
+            decoration: BoxDecoration(
+              color: Colors.yellow,
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: ListTile(
+              leading: Checkbox(
                 value: taskCompleted,
                 onChanged: onChanged,
                 activeColor: Colors.black,
               ),
-
-              // task name
-              Text(
+              title: Text(
                 taskName,
                 style: TextStyle(
                   decoration: taskCompleted
@@ -55,9 +51,7 @@ class ToDoTile extends StatelessWidget {
                       : TextDecoration.none,
                 ),
               ),
-            ],
-          ),
-        ),
+            )),
       ),
     );
   }


### PR DESCRIPTION
Replaced Row with ListTile to fix renderflex overflow issues

**BEFORE**
![Screenshot_20221007_215832](https://user-images.githubusercontent.com/50566307/194668697-43904cba-20d0-4a07-a00f-a2841eddf594.png)

**AFTER**
![Screenshot_20221007_215754](https://user-images.githubusercontent.com/50566307/194668720-e6766459-bd33-47f7-8371-ac0f17910f29.png)
